### PR TITLE
fix page 2 load errors; comment out unused scripts

### DIFF
--- a/assets/scripts/page2.js
+++ b/assets/scripts/page2.js
@@ -169,9 +169,7 @@ $(document).ready(function() {
         .attr('id', 'product-price')
         .text(`$${itemPrice.toFixed(2)}`);
 
-});
-
-
     $info.empty();
     $info.append($image, $name, $price);
+
 });

--- a/page2.html
+++ b/page2.html
@@ -24,8 +24,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
     <!-- Load the draggabilly.pkgd.js and modal.js in the html page. -->
-    <script src="js/draggabilly.pkgd.js"></script>
-    <script src="js/modal.js"></script>
+    <!-- <script src="js/draggabilly.pkgd.js"></script>
+    <script src="js/modal.js"></script> -->
 
 
     <!-- Link to Font Awesome -->
@@ -42,8 +42,6 @@
 
     <script src="assets/scripts/page2.js"></script>
     <script src="assets/scripts/app.js"></script>
-
-
 
 </head>
 
@@ -138,21 +136,9 @@
             </div>
         </div>
 
-
-
-
-
-
         <div class="container">
             <p id="time">Current Time: <span id="current-time"></span></p>
         </div>
-
-        <footer>
-        </footer>
-
-        <br>
-
-
 
 </body>
 


### PR DESCRIPTION
I removed extra closing braces that got merged into page 2. Also commented out two scripts in the header that were failing to load, throwing errors. I'm assuming they either were unintentionally not included or these script links were not removed.